### PR TITLE
Fix configless output path

### DIFF
--- a/src/supply-cmd.js
+++ b/src/supply-cmd.js
@@ -24,9 +24,9 @@ let outputPath = '.';
 let configPath = path.join(process.env.PWD, inputConfigPath);
 let config = undefined;
 
-if(inputConfigPath && fs.existsSync(configPath)){
+if(inputConfigPath && fs.existsSync(configPath)){ // if the specified file exists load it and get the output path
   config = JSON.parse(fs.readFileSync(configPath));
-  outputPath = config.outputDirectory ? config.outputDirectory : '.';
+  outputPath = config.outputDirectory ? config.outputDirectory : process.env.PWD;
 }else{
   configPath = process.env.PWD; // for the purpose of determining the output path the config path is the PWD
   console.warn('Data supply - Using default config', process.env.PWD);

--- a/src/supply-cmd.js
+++ b/src/supply-cmd.js
@@ -29,15 +29,16 @@ if(inputConfigPath && fs.existsSync(configPath)){
   outputPath = config.outputDirectory ? config.outputDirectory : '.';
 }else{
   configPath = process.env.PWD; // for the purpose of determining the output path the config path is the PWD
-  console.warn('Data supply - Using default config');
+  console.warn('Data supply - Using default config', process.env.PWD);
 }
 
 // the config path is relative to the location of 
 // 1. the configuration file or if not then 
 // 2. the present working directory
-
-outputPath = path.join(path.dirname(configPath), outputPath); 
-
+if(!fs.lstatSync(configPath).isDirectory()){
+  configPath = path.dirname(configPath)
+}
+outputPath = path.join(configPath, outputPath); 
 const dataSets = parseDataFiles(config);
 
 Object.entries(dataSets).forEach(([basename, dataSet]) => {

--- a/test/parse-config.test.js
+++ b/test/parse-config.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import parseConfig from '../src/parse-config.js';
+
+const configFixture = JSON.parse(fs.readFileSync('./test/config-fixture.json','utf-8'));
+
+const egCsv = 'a,b,c\n1,2,3\n4,5,"6,7"';
+const egTsv = 'a\tb\tc\n1\t2\t3\n4\t5\t6,7';
+const egPsv = 'a|b|c\n1|2|3\n4|5|6,7';
+
+test('does it create the right number of parsers?', () => {
+  const configuration = parseConfig(configFixture);
+  expect(Object.keys(configuration.parsers).length).toBe(2);
+});


### PR DESCRIPTION
When run without the config file present in the working directory or specified the by a command line argument, the CLI command will place the output files in the parent directory of the working directory.

This PR fixes that.

Also, adds a stub for testing config parsing